### PR TITLE
Add back serialize to unit test

### DIFF
--- a/src/transaction/serialize.c
+++ b/src/transaction/serialize.c
@@ -7,35 +7,59 @@
 #include "../common/write.h"
 #include "../common/varint.h"
 
-// int transaction_serialize(const transaction_t *tx, uint8_t *out, size_t out_len) {
-//     size_t offset = 0;
+int transaction_serialize(const transaction_t *tx, uint8_t *out, size_t out_len) {
+    size_t offset = 0;
 
-//     // if (8 + ADDRESS_LEN + 8 + varint_size(tx->memo_len) + tx->memo_len > out_len) {
-//     //     return -1;
-//     // }
+    if (out_len < 4) {
+        return -1;
+    }
 
-//     // // nonce
-//     // write_u64_be(out, offset, tx->nonce);
-//     // offset += 8;
+    write_u16_be(out, offset, tx->version);
+    offset += 2;
+    out[offset++] = tx->tx_output_len;
+    out[offset++] = tx->tx_input_len;
 
-//     // // to
-//     // memmove(out + offset, tx->to, ADDRESS_LEN);
-//     // offset += ADDRESS_LEN;
+    return (int) offset;
+}
 
-//     // // value
-//     // write_u64_be(out, offset, tx->value);
-//     // offset += 8;
+int transaction_input_serialize(const transaction_input_t *txin, uint8_t *out, size_t out_len) {
+    size_t offset = 0;
 
-//     // // memo length
-//     // int varint_len = varint_write(out, offset, tx->memo_len);
-//     // if (varint_len < 0) {
-//     //     return -1;
-//     // }
-//     // offset += varint_len;
+    if (out_len < 46) {
+        return -1;
+    }
 
-//     // // memo
-//     // memmove(out + offset, tx->memo, tx->memo_len);
-//     // offset += tx->memo_len;
+    write_u64_be(out, offset, txin->value);
+    offset += 8;
 
-//     return (int) offset;
-// }
+    memcpy(out + offset, txin->tx_id, 32);
+    offset += 32;
+
+    out[offset++] = txin->address_type;
+
+    write_u32_be(out, offset, txin->address_index);
+    offset += 4;
+
+    out[offset++] = txin->index;
+
+    return (int) offset;
+}
+
+int transaction_output_serialize(const transaction_output_t *txout, uint8_t *out, size_t out_len) {
+    size_t offset = 0;
+
+    if (out_len < 41) {
+        return -1;
+    }
+
+    write_u64_be(out, offset, txout->value);
+    offset += 8;
+
+    size_t script_len = txout->script_public_key[0];
+
+    memcpy(out + offset, txout->script_public_key, script_len + 2);
+
+    offset += script_len + 2;
+
+    return (int) offset;
+}

--- a/unit-tests/test_tx_parser.c
+++ b/unit-tests/test_tx_parser.c
@@ -31,10 +31,10 @@ static void test_tx_serialization(void **state) {
     assert_int_equal(status, PARSING_OK);
     assert_int_equal(tx.version, 1);
 
-    // uint8_t output[350];
-    // int length = transaction_serialize(&tx, output, sizeof(output));
-    // assert_int_equal(length, sizeof(raw_tx));
-    // assert_memory_equal(raw_tx, output, sizeof(raw_tx));
+    uint8_t output[350];
+    int length = transaction_serialize(&tx, output, sizeof(output));
+    assert_int_equal(length, sizeof(raw_tx));
+    assert_memory_equal(raw_tx, output, sizeof(raw_tx));
 }
 
 static void test_tx_input_serialization(void **state) {
@@ -59,6 +59,10 @@ static void test_tx_input_serialization(void **state) {
 
     assert_int_equal(status, PARSING_OK);
 
+    uint8_t output[350];
+    int length = transaction_input_serialize(&txin, output, sizeof(output));
+    assert_int_equal(length, sizeof(raw_tx));
+    assert_memory_equal(raw_tx, output, sizeof(raw_tx));
 }
 
 static void test_tx_output_serialization_32_bytes(void **state) {
@@ -84,6 +88,10 @@ static void test_tx_output_serialization_32_bytes(void **state) {
 
     assert_int_equal(status, PARSING_OK);
 
+    uint8_t output[350];
+    int length = transaction_output_serialize(&txout, output, sizeof(output));
+    assert_int_equal(length, sizeof(raw_tx));
+    assert_memory_equal(raw_tx, output, sizeof(raw_tx));
 }
 
 static void test_tx_output_serialization_33_bytes(void **state) {
@@ -109,6 +117,10 @@ static void test_tx_output_serialization_33_bytes(void **state) {
 
     assert_int_equal(status, PARSING_OK);
 
+    uint8_t output[350];
+    int length = transaction_output_serialize(&txout, output, sizeof(output));
+    assert_int_equal(length, sizeof(raw_tx));
+    assert_memory_equal(raw_tx, output, sizeof(raw_tx));
 }
 
 int main() {


### PR DESCRIPTION
Add back serialize.c to ensure the data we process is the same that was passed

Fixes #19